### PR TITLE
Implement ZTP configuration playbook

### DIFF
--- a/dc1-ztp-configuration.yml
+++ b/dc1-ztp-configuration.yml
@@ -1,0 +1,37 @@
+---
+- name: Configure ZTP service on CloudVision
+  hosts: ztp
+  gather_facts: no
+  vars:
+    ztp:
+      general:
+        network: 10.255.0.0
+        netmask: 255.255.255.0
+        gateway: 10.255.0.1
+        nameserver: '1.1.1.1, 8.8.8.8'
+        start: 10.255.0.200
+        end: 10.255.0.250
+        registration: 'http://10.255.0.1/ztp/bootstrap'
+      clients:
+        - name: DC1-SPINE1
+          mac: 0c:1d:c0:1d:62:01
+          ip4: 10.255.0.11
+        - name: DC1-SPINE2
+          mac: 0c:1d:c0:1d:62:02
+          ip4: 10.255.0.12
+        - name: DC1-LEAF1A
+          mac: 0c:1d:c0:1d:62:11
+          ip4: 10.255.0.13
+        - name: DC1-LEAF1B
+          mac: 0c:1d:c0:1d:62:12
+          ip4: 10.255.0.14
+        - name: DC1-LEAF2A
+          mac: 0c:1d:c0:1d:62:13
+          ip4: 10.255.0.15
+        - name: DC1-LEAF2B
+          mac: 0c:1d:c0:1d:62:14
+          ip4: 10.255.0.16
+  tasks:
+  - name: 'Execute ZTP configuration role'
+    import_role:
+      name: ztp-setup

--- a/inventory.yml
+++ b/inventory.yml
@@ -2,6 +2,10 @@ all:
   children:
     CVP:
       hosts:
+        ztp:
+          ansible_host: 10.83.28.164
+          ansible_user: root
+          ansible_password: ansible
         cvp:
           ansible_httpapi_host: 10.83.28.164
           ansible_host: 10.83.28.164

--- a/roles/ztp-setup/.travis.yml
+++ b/roles/ztp-setup/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/roles/ztp-setup/README.md
+++ b/roles/ztp-setup/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/roles/ztp-setup/defaults/main.yml
+++ b/roles/ztp-setup/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for ztp-setup

--- a/roles/ztp-setup/handlers/main.yml
+++ b/roles/ztp-setup/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for ztp-setup

--- a/roles/ztp-setup/meta/main.yml
+++ b/roles/ztp-setup/meta/main.yml
@@ -1,0 +1,53 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.9
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+  

--- a/roles/ztp-setup/tasks/main.yml
+++ b/roles/ztp-setup/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+# tasks file for ztp-setup
+- name: 'Generate DHCPd configuration file'
+  template:
+    src: 'dhcpd.conf.j2'
+    dest: /etc/dhcp/dhcpd.conf
+    backup: yes
+
+- name: Check & activate DHCP service on {{inventory_hostname}}
+  service:
+    name: dhcpd
+    enabled: yes
+
+- name: Restart DHCP service on {{inventory_hostname}}
+  service:
+    name: dhcpd
+    state: restarted

--- a/roles/ztp-setup/templates/dhcpd.conf.j2
+++ b/roles/ztp-setup/templates/dhcpd.conf.j2
@@ -1,0 +1,18 @@
+# Subnet of ZTP interface
+subnet {{ztp.general.network}} netmask {{ztp.general.netmask}} {
+    range {{ztp.general.start}} {{ztp.general.end}};
+    option routers {{ztp.general.gateway}};
+    option domain-name-servers 10.83.28.52, 10.83.29.222;
+    option bootfile-name "{{ztp.general.registration}}";
+}
+
+# Per host definition
+{% for client in ztp.clients %}
+host {{client.name}} {
+    option host-name "{{client.name}}";
+    hardware ethernet {{client.mac}};
+    fixed-address {{client.ip4}};
+    option bootfile-name "{{ztp.general.registration}}";
+}
+
+{% endfor %}

--- a/roles/ztp-setup/tests/inventory
+++ b/roles/ztp-setup/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/ztp-setup/tests/test.yml
+++ b/roles/ztp-setup/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - ztp-setup

--- a/roles/ztp-setup/vars/main.yml
+++ b/roles/ztp-setup/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for ztp-setup


### PR DESCRIPTION
Implement initial ZTP configuration playbook:

- Require specific host definition in `inventory.yml`
- Update vars to fit with lab in `dc1-ztp-configuration.yml`

Role to fit with basic environment and not a full ztp configuration playbook / role.